### PR TITLE
Corrected a problem with button taps not making it through to dismissWit...

### DIFF
--- a/WordPressApi/WPHTTPAuthenticationAlertView.h
+++ b/WordPressApi/WPHTTPAuthenticationAlertView.h
@@ -7,8 +7,11 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "AFHTTPRequestOperation.h"
 
-@interface WPHTTPAuthenticationAlertView : UIAlertView
+@interface WPHTTPAuthenticationAlertView : NSObject <UIAlertViewDelegate>
+
 - (id)initWithChallenge:(NSURLAuthenticationChallenge *)challenge;
+
+- (void)show;
+
 @end

--- a/WordPressApi/WPHTTPAuthenticationAlertView.m
+++ b/WordPressApi/WPHTTPAuthenticationAlertView.m
@@ -9,34 +9,35 @@
 #import "WPHTTPAuthenticationAlertView.h"
 
 @implementation WPHTTPAuthenticationAlertView {
+    UIAlertView *_alertView;
     NSURLAuthenticationChallenge *_challenge;
     UITextField *usernameField, *passwordField;
 }
 
-
 - (id)initWithChallenge:(NSURLAuthenticationChallenge *)challenge {
-    self = [self initWithTitle:nil
-                       message:nil
-                      delegate:nil
-             cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel button label.")
-             otherButtonTitles:nil];
+    self = [super init];
     
     if (self) {
+        _alertView = [[UIAlertView alloc] initWithTitle:nil
+                                                message:nil
+                                               delegate:self
+                                      cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel button label.")
+                                      otherButtonTitles:nil];
         _challenge = challenge;
-        self.delegate = self;
         
         if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
-            self.alertViewStyle = UIAlertViewStyleDefault;
-            self.title = NSLocalizedString(@"Certificate error", @"Popup title for wrong SSL certificate.");
-            self.message = [NSString stringWithFormat:NSLocalizedString(@"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?", @""), challenge.protectionSpace.host];
-            [self addButtonWithTitle:NSLocalizedString(@"Trust", @"Connect when the SSL certificate is invalid")];
+            _alertView.alertViewStyle = UIAlertViewStyleDefault;
+            _alertView.title = NSLocalizedString(@"Certificate error", @"Popup title for wrong SSL certificate.");
+            _alertView.message = [NSString stringWithFormat:NSLocalizedString(@"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?", @""), challenge.protectionSpace.host];
+            [_alertView addButtonWithTitle:NSLocalizedString(@"Trust", @"Connect when the SSL certificate is invalid")];
         } else {
-            self.alertViewStyle = UIAlertViewStyleLoginAndPasswordInput;
-            self.title = NSLocalizedString(@"Authentication required", @"Popup title to ask for user credentials.");
-            self.message = NSLocalizedString(@"Please enter your credentials", @"Popup message to ask for user credentials (fields shown below).");
-            [self addButtonWithTitle:NSLocalizedString(@"Log In", @"Log In button label.")];
+            _alertView.alertViewStyle = UIAlertViewStyleLoginAndPasswordInput;
+            _alertView.title = NSLocalizedString(@"Authentication required", @"Popup title to ask for user credentials.");
+            _alertView.message = NSLocalizedString(@"Please enter your credentials", @"Popup message to ask for user credentials (fields shown below).");
+            [_alertView addButtonWithTitle:NSLocalizedString(@"Log In", @"Log In button label.")];
         }
     }
+    
     return self;
 }
 
@@ -50,8 +51,8 @@
         } else {
             NSString *username, *password;
             if ([self respondsToSelector:@selector(setAlertViewStyle:)]) {
-                username = [[self textFieldAtIndex:0] text];
-                password = [[self textFieldAtIndex:1] text];
+                username = [[alertView textFieldAtIndex:0] text];
+                password = [[alertView textFieldAtIndex:1] text];
             } else {
                 username = usernameField.text;
                 password = passwordField.text;
@@ -64,6 +65,11 @@
     } else {
         [[_challenge sender] cancelAuthenticationChallenge:_challenge];
     }
+}
+
+- (void)show
+{
+    [_alertView show];
 }
 
 @end


### PR DESCRIPTION
...hClickedButtonIndex.

Should eventually make this a proxy/wrapper for a UIAlertView rather than extending it.

Taken from https://github.com/wordpress-mobile/WordPress-iOS/commit/6a2c56de63f0bc4422e35c6a4c758b707abd9442
