### PR TITLE
Use compression for iOS 7.1 and later, but not earlier versions.

### DIFF
--- a/WordPressApi/WPXMLRPCClient.m
+++ b/WordPressApi/WPXMLRPCClient.m
@@ -48,8 +48,14 @@ static NSUInteger const WPXMLRPCClientDefaultMaxConcurrentOperationCount = 4;
     self.defaultHeaders = [NSMutableDictionary dictionary];
 
 	// Accept-Encoding HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
-    // Disable compression by default, since it causes connection problems with some hosts
-	[self setDefaultHeader:@"Accept-Encoding" value:@"identity"];
+    if (([[[UIDevice currentDevice] systemVersion] compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending)) {
+        // if iOS 7.1 or later
+        [self setDefaultHeader:@"Accept-Encoding" value:@"gzip, deflate"];
+    } else {
+        // Disable compression by default, since it causes connection problems with some hosts
+        // Fixed in iOS SDK 7.1 see: https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-7.1/
+        [self setDefaultHeader:@"Accept-Encoding" value:@"identity"];
+    }
     [self setDefaultHeader:@"Content-Type" value:@"text/xml"];
 
     NSString *applicationUserAgent = [[NSUserDefaults standardUserDefaults] objectForKey:@"UserAgent"];


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/issues/1626
