### PR TITLE
Fixes HTTP Authentication

### DIFF
--- a/WordPressApi/WPHTTPRequestOperation.m
+++ b/WordPressApi/WPHTTPRequestOperation.m
@@ -15,12 +15,7 @@
 
 #pragma mark - NSURLConnectionDelegate
 
-- (BOOL)connection:(NSURLConnection *)connection canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace
-{
-	return ![protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate];
-}
-
-- (void)connection:(NSURLConnection *)connection didCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
 	if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
 		// Handle invalid certificates
@@ -34,6 +29,8 @@
 		} else {
 			[challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge];
 		}
+    } else if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate]) {
+        [challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge];
 	} else {
 		NSURLCredential *credential = [[NSURLCredentialStorage sharedCredentialStorage] defaultCredentialForProtectionSpace:[challenge protectionSpace]];
 		


### PR DESCRIPTION
After the migration to AFNetworking2, HTTP Auth stopped working.
Probably self-signed certificates as well.

`connection:canAuthenticateAgainstProtectionSpace:` will only be called
if the delegate doesn't implement
`connection:willSendRequestForAuthenticationChallenge:`, which
`AFURLConnectionOperation` does.

Fixes wordpress-mobile/WordPress-iOS#2129

Possibly related issues:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/1232
- https://github.com/wordpress-mobile/WordPress-iOS/issues/1933
