### PR TITLE
Bearer Token Support

### DIFF
--- a/WordPressApi.podspec
+++ b/WordPressApi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressApi"
-  s.version      = "0.3.1"
+  s.version      = "0.3.2"
   s.summary      = "A simple Objective-C client to publish posts on the WordPress platform"
   s.homepage     = "https://github.com/wordpress-mobile/WordPressApi"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/WordPressApi/WPComOAuthController.h
+++ b/WordPressApi/WPComOAuthController.h
@@ -11,6 +11,7 @@ typedef NS_ENUM(NSUInteger, WPComOAuthErrorCode) {
 
 - (void)setWordPressComUsername:(NSString *)username;
 - (void)setWordPressComPassword:(NSString *)password;
+- (void)setWordPressComAuthToken:(NSString *)authToken;
 
 - (void)setClient:(NSString *)client;
 - (void)setRedirectUrl:(NSString *)redirectUrl;

--- a/WordPressApi/WPComOAuthController.m
+++ b/WordPressApi/WPComOAuthController.m
@@ -74,7 +74,7 @@ NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
 }
 
 - (void)setCompletionBlock:(void (^)(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error))completionBlock {
-    _completionBlock = completionBlock;
+    _completionBlock = [completionBlock copy];
 }
 
 #pragma mark - View lifecycle

--- a/WordPressApi/WPComOAuthController.m
+++ b/WordPressApi/WPComOAuthController.m
@@ -19,8 +19,13 @@ NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
 @end
 
 @implementation WPComOAuthController {
-    NSString *_clientId, *_redirectUrl, *_scope, *_blogId, *_secret;
-    NSString *_username, *_password;
+    NSString *_clientId;
+    NSString *_redirectUrl;
+    NSString *_scope;
+    NSString *_blogId;
+    NSString *_secret;
+    NSString *_username;
+    NSString *_password;
     BOOL _isSSO;
     void (^_completionBlock)(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error);
 }

--- a/WordPressApi/WPComOAuthController.m
+++ b/WordPressApi/WPComOAuthController.m
@@ -26,6 +26,7 @@ NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
     NSString *_secret;
     NSString *_username;
     NSString *_password;
+    NSString *_authToken;
     BOOL _isSSO;
     void (^_completionBlock)(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error);
 }
@@ -64,6 +65,10 @@ NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
 
 - (void)setWordPressComPassword:(NSString *)password {
     _password = password;
+}
+
+- (void)setWordPressComAuthToken:(NSString *)authToken {
+    _authToken = authToken;
 }
 
 - (void)setClient:(NSString *)client {
@@ -133,6 +138,9 @@ NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
         [request setHTTPBody:[request_body dataUsingEncoding:NSUTF8StringEncoding]];
         [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[request_body length]] forHTTPHeaderField:@"Content-Length"];
         [request addValue:@"*/*" forHTTPHeaderField:@"Accept"];
+        if (_authToken) {
+            [request addValue:[NSString stringWithFormat:@"Bearer %@", _authToken] forHTTPHeaderField:@"Authorization"];
+        }
         [request setHTTPMethod:@"POST"];
     }
     [self.webView loadRequest:request];
@@ -283,6 +291,7 @@ NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
             WPComOAuthController *ssoController = [[WPComOAuthController alloc] initForSSO];
             [ssoController setWordPressComUsername:_username];
             [ssoController setWordPressComPassword:_password];
+            [ssoController setWordPressComAuthToken:_authToken];
             [ssoController setClient:clientId];
             [ssoController setRedirectUrl:redirectUrl];
             [ssoController present];

--- a/WordPressApiExample/WordPressApiExample.xcodeproj/project.pbxproj
+++ b/WordPressApiExample/WordPressApiExample.xcodeproj/project.pbxproj
@@ -238,7 +238,7 @@
 		E1F753CA14A094F400DB35A3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = Automattic;
 			};
 			buildConfigurationList = E1F753CD14A094F400DB35A3 /* Build configuration list for PBXProject "WordPressApiExample" */;
@@ -345,9 +345,11 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -379,9 +381,11 @@
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;


### PR DESCRIPTION
#### Details:
- Updates WPComOAuthController so that the user is authenticated via *Bearer Token*.
- Fixed a callbackBlock setter (that definitely needed a copy call)

#### Testing:
1. Install WPiOS and Sign Into a dotcom account.
2. Add a [new testing WordPress App Here](https://developer.wordpress.com/apps/)
3. Open this url in Safari.app: `wordpress-oauth-v2://authorize?client_id=[App ID]&redirect_url=[Callback URL]`

As a result, WPiOS should be onscreen, and the user should be asked whether if he wants to authorize or not the app.

**Note:**
**WordPressAppDelegate**'s **setupSingleSignOn** method should be patched, so that the authToken is initialized.

Closes #34. This is a blocker for [this WPiOS issue](https://github.com/wordpress-mobile/WordPress-iOS/pull/3308).

/cc @sendhil 

(Thanks in advance!).

